### PR TITLE
rm deprecated View.propTypes (Replaced by ViewPropTypes)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,8 @@ import {
   View,
   TouchableOpacity,
   StyleSheet,
-  Text
+  Text,
+  ViewPropTypes
 } from 'react-native'
 
 export default class extends Component {
@@ -24,7 +25,7 @@ export default class extends Component {
     selected: PropTypes.number,
     borderRadius: PropTypes.number,
     borderColor: PropTypes.string,
-    style: View.propTypes.style
+    style: ViewPropTypes.style
   };
 
   static defaultProps = { // 返回默认的一些属性值


### PR DESCRIPTION
Remove deprected `View.propTypes`.
This causes an undefined object on release version.

This was replaced by `ViewPropTypes`